### PR TITLE
htmlのタグに関する部分の間違いを修正

### DIFF
--- a/internal_design_document/internal_design_document.tex
+++ b/internal_design_document/internal_design_document.tex
@@ -130,7 +130,7 @@ Ruby on Railsは、コーディング解析ツール「RuboCop」を使用して
 metaタグは以下の通りです。
 
 \begin{itemize}
-<meta charset = "utf-8">
+\item \textless meta charset="utf-8"\textgreater
 \end{itemize}
 
 
@@ -138,7 +138,7 @@ metaタグは以下の通りです。
 linkタグは以下の通りです。
 
 \begin{itemize}
-<link rel="stylesheet" href=".css" type="text/css">
+\item \textless link rel="stylesheet" href=".css" type="text/css"\textgreater
 \end{itemize}
 
 
@@ -146,7 +146,7 @@ linkタグは以下の通りです。
 scriptタグは以下の通りです。
 
 \begin{itemize}
-<script type="text/javascript" src=".js"></script>
+\item \textless script type="text/javascript" src=".js"\textgreater \textless /script\textgreater
 \end{itemize}
 
 \end{description}


### PR DESCRIPTION
texをコンパイルできなかったので修正。
texでは不等号をそのままでは扱えないよ
